### PR TITLE
Kari/no double combine

### DIFF
--- a/javascripts/2048.js
+++ b/javascripts/2048.js
@@ -86,7 +86,7 @@ function checkNextSpace(active_tile, direction) {
     checkNextSpace(active_tile,direction);
 
   // if next_tile exists and is the same as active_tile, combine them 
-  } else if ( parseInt(next_tile.attr('data-val')) == data_val ) {              
+  } else if ( parseInt(next_tile.attr('data-val')) == data_val && next_tile.attr('combined') == "false") {              
     var new_tile_value = combineTiles(active_tile, next_tile);
 
     // check for win
@@ -134,6 +134,8 @@ function moveTile(tile, direction) {
   } else {
     addTile();
   }
+
+  $('.tile').attr('combined','false');          // reset combined to false for next round of checks
 }
 
 
@@ -142,6 +144,7 @@ function combineTiles(active_tile, next_tile) {
 
   // update next_tile's val
   next_tile.attr('data-val', new_tile_value);
+  next_tile.attr('combined', 'true');
   next_tile.text(new_tile_value);
 
   // active_tile disappears
@@ -205,6 +208,7 @@ function addTile() {
   new_tile.html(random_tile_value);
   // add tile to board
   $("#gameboard").append(new_tile);
+  new_tile.attr('combined','false');
   pop(new_tile);
 } // end addTile
 


### PR DESCRIPTION
Fixed bug where tiles would combine multiple times. Ex: 2+2 -> 4, then it would combine with another 4. Now it will only allow a tile to combine once per movement.
